### PR TITLE
(feat) Make nodes with multiple parents display correctly on the page

### DIFF
--- a/dndTree.js
+++ b/dndTree.js
@@ -183,19 +183,8 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         });
         // if nodes has children, remove the links and nodes
         if (nodes.length > 1) {
-
-
-
-
-            ///////////////////////
             // remove link paths //
-            ///////////////////////
-            links = tree.links(nodes);
-            // console.log('Our tree\'s links: ', links)
-
-
-
-            
+            links = tree.links(nodes);            
             nodePaths = svgGroup.selectAll("path.link")
                 .data(links, function(d) {
                     return d.target.id;
@@ -212,16 +201,10 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
                 }).remove();
         }
 
-
-
-
         ////////////////////////
         // remove parent link //
         ////////////////////////
         parentLink = tree.links(tree.nodes(draggingNode.parent));
-
-
-
 
         svgGroup.selectAll('path.link').filter(function(d, i) {
             if (d.target.id == draggingNode.id) {
@@ -239,7 +222,6 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         .attr("height", viewerHeight)
         .attr("class", "overlay")
         .call(zoomListener);
-
 
     // Define the drag listeners for drag/drop behaviour of nodes.
     dragListener = d3.behavior.drag()
@@ -296,17 +278,11 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             domNode = this;
             if (selectedNode) {
 
-
-
-
                 // now remove the element from the parent, and insert it into the new elements children
                 var index = draggingNode.parent.children.indexOf(draggingNode);
                 if (index > -1) {
                     draggingNode.parent.children.splice(index, 1);
                 }
-
-
-
 
                 if (typeof selectedNode.children !== 'undefined' || typeof selectedNode._children !== 'undefined') {
                     if (typeof selectedNode.children !== 'undefined') {
@@ -462,10 +438,10 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         var newHeight = d3.max(levelWidth) * 25; // 25 pixels per line  
         tree = tree.size([newHeight, viewerWidth]);
 
-        console.log(root)
-
         // Compute the new tree layout.
         var nodesWithDupes = tree.nodes(root);
+        console.log(nodesWithDupes);
+        console.log(tree.nodes)
         let nodes = [];
 
         nodesWithDupes.forEach(node => {
@@ -482,6 +458,16 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         });
 
         nodes = nodes.reverse();
+
+        function fixXCoord(nodesArray) {
+            nodesArray.forEach(node => {
+                if(node.x > 400) //set arbitrarily
+                    node.x = node.parent.x + 25;
+            });
+        }
+
+        fixXCoord(nodes);
+
         var links = tree.links(nodes);
 
         // Set widths between levels based on maxLabelLength.
@@ -511,6 +497,7 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             .attr('class', 'nodeCircle')
             .attr("r", 0)
             .style("fill", function(d) {
+                console.log(d.name, d.x, d.y)
                 return d._children ? "lightsteelblue" : "#fff";
             });
 
@@ -665,32 +652,6 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
                 multiParents.push(linkObj);
             }
         });
-
-        console.log(multiParents)
-        console.log(links)
-
-    
-        // multiParents.forEach(function(multiPair) {
-        //         svgGroup.append("path", "g")
-        //         .attr("class", "additionalParentLink")
-        //             .attr("d", function() {
-        //                 var oTarget = {
-        //                     x: multiPair.parent.x0,
-        //                     y: multiPair.parent.y0
-        //                 };
-        //                 var oSource = {
-        //                     x: multiPair.child.x0,
-        //                     y: multiPair.child.y0
-        //                 };
-        //                 // if (multiPair.child.depth === multiPair.couplingParent1.depth) {
-        //                 //     return "M" + oSource.y + " " + oSource.x + " L" + (oTarget.y + ((Math.abs((oTarget.x - oSource.x))) * 0.25)) + " " + oTarget.x + " " + oTarget.y + " " + oTarget.x;
-        //                 // }
-        //                 return diagonal({
-        //                     source: oSource,
-        //                     target: oTarget
-        //                 });
-        //             });
-        // });
     }
 
     // Append a group which holds all nodes and which the zoom Listener can act upon.

--- a/dndTree.js
+++ b/dndTree.js
@@ -462,32 +462,27 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         var newHeight = d3.max(levelWidth) * 25; // 25 pixels per line  
         tree = tree.size([newHeight, viewerWidth]);
 
+        console.log(root)
+
         // Compute the new tree layout.
-        var nodes = tree.nodes(root).reverse(),
-            links = tree.links(nodes);
-            // console.log('in update: ');
-            // links.forEach(link => {
-            //     console.log(`s: ${link.source.name}, t: ${link.target.name}`)
-            // });
+        var nodesWithDupes = tree.nodes(root);
+        let nodes = [];
 
-            // myLinks = [];
-            // nodes.forEach(node => {
-            //     if(node.parents) {
-            //         node.parents.forEach(parent => {
-            //             myLinks.push({
-            //                 source: parent,
-            //                 target: node
-            //             });
-            //         });
-            //     }
-            // });
+        nodesWithDupes.forEach(node => {
+            let exists = false;
+            nodes.forEach(alreadyPresent => {
+                if(alreadyPresent.name === node.name) {
+                    exists = true;
+                }
+            });
 
-            // links = myLinks;
+            if(!exists) {
+                nodes.push(node);
+            }
+        });
 
-            // console.log('\n\nMy links: ');
-            // myLinks.forEach(link => {
-            //     console.log(`s: ${link.source.name}, t: ${link.target.name}`)
-            // });
+        nodes = nodes.reverse();
+        var links = tree.links(nodes);
 
         // Set widths between levels based on maxLabelLength.
         nodes.forEach(function(d) {
@@ -594,7 +589,8 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         // Update the links…
         var link = svgGroup.selectAll("path.link")
             .data(links, function(d) {
-                return d.target.id;
+                return Math.floor(Math.random() * 1000000000);
+                // return d.target.id;
             });
 
         // Enter any new links at the parent's previous position.
@@ -644,38 +640,57 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             return false;
         });
 
-        const multiParents = [];
+        const multiParentsWithDupes = [];
 
         nodesWith2Parents.forEach(node => {
             node.parents.forEach(parent => {
-                multiParents.push({
+                multiParentsWithDupes.push({
                     parent: parent,
                     child: node
                 });
             });
-        });  
-    
-        multiParents.forEach(function(multiPair) {
-                svgGroup.append("path", "g")
-                .attr("class", "additionalParentLink")
-                    .attr("d", function() {
-                        var oTarget = {
-                            x: multiPair.parent.x0,
-                            y: multiPair.parent.y0
-                        };
-                        var oSource = {
-                            x: multiPair.child.x0,
-                            y: multiPair.child.y0
-                        };
-                        // if (multiPair.child.depth === multiPair.couplingParent1.depth) {
-                        //     return "M" + oSource.y + " " + oSource.x + " L" + (oTarget.y + ((Math.abs((oTarget.x - oSource.x))) * 0.25)) + " " + oTarget.x + " " + oTarget.y + " " + oTarget.x;
-                        // }
-                        return diagonal({
-                            source: oSource,
-                            target: oTarget
-                        });
-                    });
         });
+
+        const multiParents = [];
+
+        multiParentsWithDupes.forEach(linkObj => {
+            let exists = false;
+            multiParents.forEach(item => {
+                if(item.parent === linkObj.parent && item.child === linkObj.child) {
+                    exists = true;
+                }
+            });
+
+            if(!exists) {
+                multiParents.push(linkObj);
+            }
+        });
+
+        console.log(multiParents)
+        console.log(links)
+
+    
+        // multiParents.forEach(function(multiPair) {
+        //         svgGroup.append("path", "g")
+        //         .attr("class", "additionalParentLink")
+        //             .attr("d", function() {
+        //                 var oTarget = {
+        //                     x: multiPair.parent.x0,
+        //                     y: multiPair.parent.y0
+        //                 };
+        //                 var oSource = {
+        //                     x: multiPair.child.x0,
+        //                     y: multiPair.child.y0
+        //                 };
+        //                 // if (multiPair.child.depth === multiPair.couplingParent1.depth) {
+        //                 //     return "M" + oSource.y + " " + oSource.x + " L" + (oTarget.y + ((Math.abs((oTarget.x - oSource.x))) * 0.25)) + " " + oTarget.x + " " + oTarget.y + " " + oTarget.x;
+        //                 // }
+        //                 return diagonal({
+        //                     source: oSource,
+        //                     target: oTarget
+        //                 });
+        //             });
+        // });
     }
 
     // Append a group which holds all nodes and which the zoom Listener can act upon.

--- a/dndTree.js
+++ b/dndTree.js
@@ -113,7 +113,6 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
     }
 
     mergeBranches();
-    console.log(root);
 
     // Call visit function to establish maxLabelLength
     visit(treeData, function(d) {
@@ -184,8 +183,19 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
         });
         // if nodes has children, remove the links and nodes
         if (nodes.length > 1) {
-            // remove link paths
+
+
+
+
+            ///////////////////////
+            // remove link paths //
+            ///////////////////////
             links = tree.links(nodes);
+            // console.log('Our tree\'s links: ', links)
+
+
+
+            
             nodePaths = svgGroup.selectAll("path.link")
                 .data(links, function(d) {
                     return d.target.id;
@@ -202,8 +212,17 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
                 }).remove();
         }
 
-        // remove parent link
+
+
+
+        ////////////////////////
+        // remove parent link //
+        ////////////////////////
         parentLink = tree.links(tree.nodes(draggingNode.parent));
+
+
+
+
         svgGroup.selectAll('path.link').filter(function(d, i) {
             if (d.target.id == draggingNode.id) {
                 return true;
@@ -276,11 +295,19 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             }
             domNode = this;
             if (selectedNode) {
+
+
+
+
                 // now remove the element from the parent, and insert it into the new elements children
                 var index = draggingNode.parent.children.indexOf(draggingNode);
                 if (index > -1) {
                     draggingNode.parent.children.splice(index, 1);
                 }
+
+
+
+
                 if (typeof selectedNode.children !== 'undefined' || typeof selectedNode._children !== 'undefined') {
                     if (typeof selectedNode.children !== 'undefined') {
                         selectedNode.children.push(draggingNode);
@@ -416,19 +443,51 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             if (n.children && n.children.length > 0) {
                 if (levelWidth.length <= level + 1) levelWidth.push(0);
 
-                levelWidth[level + 1] += n.children.length;
+                n.children.forEach(child => {
+                    if(!child.counted) {
+                        levelWidth[level + 1]++;
+                        child.counted = true;
+                    }
+                })
+
                 n.children.forEach(function(d) {
-                    childCount(level + 1, d);
+                        childCount(level + 1, d);
                 });
             }
         };
+
         childCount(0, root);
+        setFalse(root, 'counted');
+
         var newHeight = d3.max(levelWidth) * 25; // 25 pixels per line  
         tree = tree.size([newHeight, viewerWidth]);
 
         // Compute the new tree layout.
         var nodes = tree.nodes(root).reverse(),
             links = tree.links(nodes);
+            // console.log('in update: ');
+            // links.forEach(link => {
+            //     console.log(`s: ${link.source.name}, t: ${link.target.name}`)
+            // });
+
+            // myLinks = [];
+            // nodes.forEach(node => {
+            //     if(node.parents) {
+            //         node.parents.forEach(parent => {
+            //             myLinks.push({
+            //                 source: parent,
+            //                 target: node
+            //             });
+            //         });
+            //     }
+            // });
+
+            // links = myLinks;
+
+            // console.log('\n\nMy links: ');
+            // myLinks.forEach(link => {
+            //     console.log(`s: ${link.source.name}, t: ${link.target.name}`)
+            // });
 
         // Set widths between levels based on maxLabelLength.
         nodes.forEach(function(d) {
@@ -577,6 +636,46 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
             d.x0 = d.x;
             d.y0 = d.y;
         });
+
+        const nodesWith2Parents = nodes.filter(node => {
+            if(node.parents && node.parents.length > 1) {
+                return true;
+            }
+            return false;
+        });
+
+        const multiParents = [];
+
+        nodesWith2Parents.forEach(node => {
+            node.parents.forEach(parent => {
+                multiParents.push({
+                    parent: parent,
+                    child: node
+                });
+            });
+        });  
+    
+        multiParents.forEach(function(multiPair) {
+                svgGroup.append("path", "g")
+                .attr("class", "additionalParentLink")
+                    .attr("d", function() {
+                        var oTarget = {
+                            x: multiPair.parent.x0,
+                            y: multiPair.parent.y0
+                        };
+                        var oSource = {
+                            x: multiPair.child.x0,
+                            y: multiPair.child.y0
+                        };
+                        // if (multiPair.child.depth === multiPair.couplingParent1.depth) {
+                        //     return "M" + oSource.y + " " + oSource.x + " L" + (oTarget.y + ((Math.abs((oTarget.x - oSource.x))) * 0.25)) + " " + oTarget.x + " " + oTarget.y + " " + oTarget.x;
+                        // }
+                        return diagonal({
+                            source: oSource,
+                            target: oTarget
+                        });
+                    });
+        });
     }
 
     // Append a group which holds all nodes and which the zoom Listener can act upon.
@@ -589,38 +688,4 @@ treeJSON = d3.json("flare.json", function(error, treeData) {
     // Layout the tree initially and center on the root node.
     update(root);
     centerNode(root);
-    
-    var couplingParent1 = tree.nodes(root).filter(function(d) {
-            return d['name'] === 'cluster';
-        })[0];
-    var couplingChild1 = tree.nodes(root).filter(function(d) {
-            return d['name'] === 'JSONConverter';
-        })[0];
-    
-    multiParents = [{
-                    parent: couplingParent1,
-                    child: couplingChild1
-                }];
-    
-    multiParents.forEach(function(multiPair) {
-            svgGroup.append("path", "g")
-            .attr("class", "additionalParentLink")
-                .attr("d", function() {
-                    var oTarget = {
-                        x: multiPair.parent.x0,
-                        y: multiPair.parent.y0
-                    };
-                    var oSource = {
-                        x: multiPair.child.x0,
-                        y: multiPair.child.y0
-                    };
-                    /*if (multiPair.child.depth === multiPair.couplingParent1.depth) {
-                        return "M" + oSource.y + " " + oSource.x + " L" + (oTarget.y + ((Math.abs((oTarget.x - oSource.x))) * 0.25)) + " " + oTarget.x + " " + oTarget.y + " " + oTarget.x;
-                    }*/
-                    return diagonal({
-                        source: oSource,
-                        target: oTarget
-                    });
-                });
-        }); 
 });

--- a/flare.json
+++ b/flare.json
@@ -1,29 +1,31 @@
 {
-    "name": "Git Repo",
+    "name": "Mangonada",
     "children": [{
-        "name": "analytics",
+        "name": "Arnav",
         "children": [{
-            "name": "cluster",
+            "name": "feat",
             "coupling_id": 1,
             "children": [{
-                "name": "JSONConverter",
+                "name": "awesome merge",
                 "size": "first"
             }]
         }, {
-            "name": "graph",
+            "name": "gitgraph",
             "children": [{
-                "name": "SpanningTree",
+                "name": "d3 tree",
                 "size": 3416
             }]
         }]
     }, {
-        "name": "data",
+        "name": "Cady",
         "children": [{
-            "name": "converters",
+            "name": "experiment",
             "children": [{
-                "name": "JSONConverter",
+                "name": "awesome merge",
                 "size": "second"
             }]
-        }]
+        }, {
+                "name": "gitgraph"
+            }]
     }]
 }

--- a/flare.json
+++ b/flare.json
@@ -1,31 +1,29 @@
 {
-    "name": "Mangonada",
+    "name": "Master",
     "children": [{
-        "name": "Arnav",
+        "name": "coolfeature",
         "children": [{
-            "name": "feat",
+            "name": "coolfeature2",
             "coupling_id": 1,
             "children": [{
-                "name": "awesome merge",
+                "name": "Master4",
                 "size": "first"
             }]
         }, {
-            "name": "gitgraph",
+            "name": "experiment",
             "children": [{
                 "name": "d3 tree",
                 "size": 3416
             }]
         }]
     }, {
-        "name": "Cady",
+        "name": "Master2",
         "children": [{
-            "name": "experiment",
+            "name": "Master3",
             "children": [{
-                "name": "awesome merge",
+                "name": "Master4",
                 "size": "second"
             }]
-        }, {
-                "name": "gitgraph"
-            }]
+        }]
     }]
 }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 
 
     <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
-    <script src="http://d3js.org/d3.v3.min.js"></script>
+    <script src="http://d3js.org/d3.v3.js"></script>
 
 
     <link rel="stylesheet" type="text/css" href="bower_components/gitgraph.js/src/gitgraph.css" />


### PR DESCRIPTION
Links now connect parents to children correctly, even in the case of
multiple parents.

This was done by implementing a fixXCoords function, which checks
if the x-coordinate of each node is extremely high and change it if
it is. Could be implemented much better.

Potentially the entire dndTree.json file should probably be refactored
heavily to intorduce the functionality we want; otherwise it feels like
we will be stuck fixing patches once we start dynamically rendering
the trees.

Also, changed flare.json to look like a potential repo.
