### PR TITLE
(refactor) Spread repo_display across 3 files

### DIFF
--- a/src/containers/coordinate_generator.js
+++ b/src/containers/coordinate_generator.js
@@ -1,110 +1,124 @@
 /**
-   * Generate the x and y-coordinates for each commit. Place them as properties
-   * on the commit.
-   */
-export default function generateCoordinates(sortedCommits, commitObj, allBranches) {
-  /**
-   * Given a range of start and end values, determine if there is any
-   * overlap.
-   * @param  {Object} range1 - the first range, an object with properties
-   *                         start and end
-   * @param  {Object} range2 - the 2nd range, same properties
-   * @return {Boolean} - whether or not they overlap
-   */
-  function checkOverlap(range1, range2) {
-    return (range2.start <= range1.start && range1.start <= range2.end) ||
-      (range2.start <= range1.end && range1.end <= range2.end);
-  }
+ * coordinate_generator.js
+ * 
+ * This is the file that contains the logic for generating x and y-values
+ * for each commit. The values will be placed on that commit as properties.
+ */
 
-  /**
-   * Generate an x-value for each commit. Each commit sent in will
-   * have a higher x-value than the one before it. Useful for placing
-   * elements in order. If the next commit will flow off of the screen,
-   * reset the x-value.
-   */
-  function generateX(node) {
-    const nextValue = 40 + numCommits++ * 30;
-    // if(nextValue + 60 > pageWidth) resetXandY();
-    return nextValue;
-  }
+/**
+ * Given a range of start and end values, determine if there is any
+ * overlap.
+ */
+function checkOverlap(range1, range2) {
+  return (range2.start <= range1.start && range1.start <= range2.end) ||
+    (range2.start <= range1.end && range1.end <= range2.end);
+}
 
-  function resetXandY() {
-    numCommits = 1;
-    firstCheckForY += 80;
-  }
+/**
+ * Generate an x-value for each commit. Each commit sent in will
+ * have a higher x-value than the one before it. Useful for placing
+ * elements in order. If the next commit will flow off of the screen,
+ * reset the x-value.
+ */
+function generateX(node, commitNum) {
+  return  40 + commitNum * 30;
+}
 
-  /**
-   * Determine if the y-position we're checking will have overlaps. If so,
-   * put in a different place. Recursively checks the next y-value if the current
-   * one is already taken.
-   * @param  {String} branch - the branch name
-   * @param  {Number} y - the y-value we're checking. Is set automatically,
-   *                    or recursively.
-   * @return {Number} - the y position.
-   */
-  function generateY(branchName, y = firstCheckForY) {
-    //if we're at a new branch we need to jump to another level
-    if(branchName !== lastBranch) {
-      lastBranch = branchName;
-      return generateY(branchName, y + yOffset);
+/**
+ * Determine if the y-position we're checking will have overlaps. If so,
+ * put in a different place. Recursively checks the next y-value if the current
+ * one is already taken.
+ */
+function generateY(branchXCoordinates, takenSpaces, y, yOffset) {
+  let overlap = false;
+
+  takenSpaces.forEach(set => {
+    if(set.y === y) {
+      overlap = checkOverlap(set, branchXCoordinates);
     }
+  });
 
-    let overlap = false;
+  //if there was an overlap present, recursively try the next y-value
+  return overlap ? generateY(branchXCoordinates, takenSpaces, y + yOffset, yOffset) : y;
+}
 
-    const { start: thisBranchStartPoint, end: thisBranchEndPoint } = branchXCoordinates[branchName];
-
-    taken.forEach(set => {
-      if(set.y === y) {
-        if((set.start <= thisBranchStartPoint && thisBranchStartPoint <= set.end) ||
-          (set.start <= thisBranchEndPoint && thisBranchEndPoint <= set.end)) {
-          overlap = true;
+//Edit the y-coordinates for branches that are
+//connected but on the same y-value. If there are 2 branches
+//connected and on the same line, move one.
+function shiftChildrenFromParents(commitsArr, commitsObj, yCoordinates) {
+  let changed = false;
+ 
+  commitsArr.forEach(commit => {
+    commit.children.forEach(child => {
+      const childObj = commitsObj[child];
+      if(childObj && commit.branch !== childObj.branch) {
+        if(yCoordinates[commit.branch] === yCoordinates[childObj.branch]) {
+          yCoordinates[childObj.branch] += yOffset;
+          changed = true;
         }
       }
     });
+  });
 
-    return overlap ? generateY(branchName, y + yOffset) : y;
-  }
+  //repeat until there's nothing left to change
+  if(changed) shiftChildFromParent(commits, yCoordinates);
+}
 
+/**
+ * Given a set of branches and their x and y-coordinate values,
+ * fix any overlaps. Recursively call until there are no overlaps. Meant
+ * to fix any overlaps created by shiftChildrenFromParents.
+ * @param  {Object} xCoordinates - the x-coordinates (start and end) for
+ *                               each branch
+ * @param  {Object} yCoordinates - the y-coordinate for each branch
+ * @param  {Number} yOffset - tells us how far to shift an overlapping branch
+ */
+function fixOverlaps(xCoordinates, yCoordinates, yOffset) {
+  const branchNames = Object.keys(xCoordinates);
+  let altered = false;
+
+  branchNames.forEach(thisBranch => {
+    const thisBranchSet = xCoordinates[thisBranch];
+    branchNames.forEach(branchToCheck => {
+      //make sure it's not the same branch
+      if(thisBranch !== branchToCheck){
+        //make sure they have the same y-coordinate
+        if(yCoordinates[thisBranch] === yCoordinates[branchToCheck]){
+          const branchToCheckSet = xCoordinates[branchToCheck];
+
+          //Make sure they overlap somewhere along their x-coordinates
+          if(checkOverlap(thisBranchSet, branchToCheckSet)) {
+            yCoordinates[branchToCheck] += yOffset;
+            altered = true;
+          }
+        }
+      }
+    });
+  });
+
+  //repeat until there's nothing left to change
+  if(altered) fixOverlaps(xCoordinates, yCoordinates, yOffset);
+}
+
+export default function generateCoordinates(sortedCommits, commitsObj, allBranches) {
   /**
    * branchXCoordinates will contain the start and end x-values for
    * each commit.
-   * @type {Object}
+   * @type {Object}, format:
+   *       { branchname1: { start: i, end: j }, branchname2: { start: m, end: n }, ...}
    */
   const branchXCoordinates = {};
 
   /**
    * branchYCoordinates will the y-coordinate of each branch.
-   * @type {Object}
+   * @type {Object}, format: { branchname1: n, branchname2: m, ...}
    */
   const branchYCoordinates = { master: 360 };
-  let firstCheckForY = 360;
+
+  //the default y-value to start placing branches at
+  const defaultY = 360;
   let numCommits = 0;
   const yOffset = 40;
-
-  //Create the x-value for each commit.
-  sortedCommits.forEach(commit => {
-    commit.x = generateX(commit);
-
-    //if it's the first time we're processing a commit from this branch, create an object
-    if(!branchXCoordinates[commit.branch]) {
-      branchXCoordinates[commit.branch] = { start: commit.x };
-    }
-
-    branchXCoordinates[commit.branch].end = commit.x;
-  });
-
-
-  /**
-   * List the positions that are taken. Properties of each object are
-   * a y-value and the range (start and end) of the x-values taken for that
-   * y-value. Initialize with a hard-coded master.
-   * @type {Array}
-   */
-  const taken = [{
-    y: 360,
-    start: branchXCoordinates['master'].start,
-    end: branchXCoordinates['master'].end,
-  }];
 
   /**
    * A variable to store the last branch location. Every commit, when being
@@ -112,60 +126,55 @@ export default function generateCoordinates(sortedCommits, commitObj, allBranche
    * different. If it was different, the new branch will be placed lower.
    */
   let lastBranch;
+    
+  ///////////////////////////////////////////////////////////
+  //Create the x-value for each commit. Simple and linear. //
+  ///////////////////////////////////////////////////////////
+  sortedCommits.forEach(commit => {
+    commit.x = generateX(commit, numCommits++);
 
-  //get the y-coordinates for each branch
+    //if it's the first time we're processing a commit from
+    //this branch, create an object
+    if(!branchXCoordinates[commit.branch]) {
+      branchXCoordinates[commit.branch] = { start: commit.x };
+    }
+
+    branchXCoordinates[commit.branch].end = commit.x;
+  });
+
+  /**
+   * Contains the positions that are taken. Properties of each object are
+   * a y-value and the range (start and end) of the x-values taken for that
+   * y-value. Initialize with a hard-coded master.
+   */
+  const taken = [{
+    y: 360,
+    start: branchXCoordinates['master'].start,
+    end: branchXCoordinates['master'].end,
+  }];
+
+  ////////////////////////////////////////////////////////
+  //Create the y-coordinates for each branch. Complex.  //
+  ////////////////////////////////////////////////////////
   Object.keys(allBranches).forEach(branch => {
     if(!branchXCoordinates[branch] || branch === 'master') return;
 
-    const { start, end } = branchXCoordinates[branch];
-    const yCoordinate = generateY(branch);
+    const xCoordinates = branchXCoordinates[branch];
+    const { start, end } = xCoordinates;
+
+    //If we're at a new branch, we want to move it down, so we start at
+    //a different y-value
+    const startYValue = defaultY + (branch === lastBranch ? 0 : 40);
+    const yCoordinate = generateY(xCoordinates, taken, startYValue, yOffset);
     lastBranch = branch;
     branchYCoordinates[branch] = yCoordinate;
     taken.push({ start, end, y: yCoordinate });
   });
 
-  // if there are 2 branches connected and on the same line, move one
-  let changed = false;
-  do{
-    changed = false;
-    sortedCommits.forEach(commit => {
-      commit.children.forEach(child => {
-        const childObj = commitObj[child];
-        if(childObj && commit.branch !== childObj.branch) {
-          if(branchYCoordinates[commit.branch] === branchYCoordinates[childObj.branch]) {
-            branchYCoordinates[childObj.branch] += yOffset;
-            changed = true;
-          }
-        }
-      });
-    });
-  } while(changed);
+  //Move children away from their parents and move overlapping branches
+  shiftChildrenFromParents(sortedCommits, commitsObj, branchYCoordinates);
+  fixOverlaps(branchXCoordinates, branchYCoordinates, yOffset);
 
-  //If there are 2 branches overlapping, move one
-  const branchNames = Object.keys(branchXCoordinates);
-  let altered = false;
-  do{
-    altered = false;
-    branchNames.forEach(thisBranch => {
-      const thisBranchSet = branchXCoordinates[thisBranch];
-      branchNames.forEach(branchToCheck => {
-        //make sure it's not the same branch
-        if(thisBranch !== branchToCheck){
-          //make sure they have the same y-coordinate
-          if(branchYCoordinates[thisBranch] === branchYCoordinates[branchToCheck]){
-            const branchToCheckSet = branchXCoordinates[branchToCheck];
-
-            //Make sure they overlap somewhere along their x-coordinates
-            if(thisBranch !== branchToCheck && checkOverlap(thisBranchSet, branchToCheckSet)) {
-              branchYCoordinates[branchToCheck] += yOffset;
-              altered = true;
-            }
-          }
-        }
-      });
-    });
-  } while(altered);
-
-  //map the branchYCoordinates values over to their commits
+  //Using the y-values for the branches, set the y-values on the commits.
   sortedCommits.forEach(commit => commit.y = branchYCoordinates[commit.branch]);
-}
+};

--- a/src/containers/coordinate_generator.js
+++ b/src/containers/coordinate_generator.js
@@ -1,0 +1,171 @@
+/**
+   * Generate the x and y-coordinates for each commit. Place them as properties
+   * on the commit.
+   */
+export default function generateCoordinates(sortedCommits, commitObj, allBranches) {
+  /**
+   * Given a range of start and end values, determine if there is any
+   * overlap.
+   * @param  {Object} range1 - the first range, an object with properties
+   *                         start and end
+   * @param  {Object} range2 - the 2nd range, same properties
+   * @return {Boolean} - whether or not they overlap
+   */
+  function checkOverlap(range1, range2) {
+    return (range2.start <= range1.start && range1.start <= range2.end) ||
+      (range2.start <= range1.end && range1.end <= range2.end);
+  }
+
+  /**
+   * Generate an x-value for each commit. Each commit sent in will
+   * have a higher x-value than the one before it. Useful for placing
+   * elements in order. If the next commit will flow off of the screen,
+   * reset the x-value.
+   */
+  function generateX(node) {
+    const nextValue = 40 + numCommits++ * 30;
+    // if(nextValue + 60 > pageWidth) resetXandY();
+    return nextValue;
+  }
+
+  function resetXandY() {
+    numCommits = 1;
+    firstCheckForY += 80;
+  }
+
+  /**
+   * Determine if the y-position we're checking will have overlaps. If so,
+   * put in a different place. Recursively checks the next y-value if the current
+   * one is already taken.
+   * @param  {String} branch - the branch name
+   * @param  {Number} y - the y-value we're checking. Is set automatically,
+   *                    or recursively.
+   * @return {Number} - the y position.
+   */
+  function generateY(branchName, y = firstCheckForY) {
+    //if we're at a new branch we need to jump to another level
+    if(branchName !== lastBranch) {
+      lastBranch = branchName;
+      return generateY(branchName, y + yOffset);
+    }
+
+    let overlap = false;
+
+    const { start: thisBranchStartPoint, end: thisBranchEndPoint } = branchXCoordinates[branchName];
+
+    taken.forEach(set => {
+      if(set.y === y) {
+        if((set.start <= thisBranchStartPoint && thisBranchStartPoint <= set.end) ||
+          (set.start <= thisBranchEndPoint && thisBranchEndPoint <= set.end)) {
+          overlap = true;
+        }
+      }
+    });
+
+    return overlap ? generateY(branchName, y + yOffset) : y;
+  }
+
+  /**
+   * branchXCoordinates will contain the start and end x-values for
+   * each commit.
+   * @type {Object}
+   */
+  const branchXCoordinates = {};
+
+  /**
+   * branchYCoordinates will the y-coordinate of each branch.
+   * @type {Object}
+   */
+  const branchYCoordinates = { master: 360 };
+  let firstCheckForY = 360;
+  let numCommits = 0;
+  const yOffset = 40;
+
+  //Create the x-value for each commit.
+  sortedCommits.forEach(commit => {
+    commit.x = generateX(commit);
+
+    //if it's the first time we're processing a commit from this branch, create an object
+    if(!branchXCoordinates[commit.branch]) {
+      branchXCoordinates[commit.branch] = { start: commit.x };
+    }
+
+    branchXCoordinates[commit.branch].end = commit.x;
+  });
+
+
+  /**
+   * List the positions that are taken. Properties of each object are
+   * a y-value and the range (start and end) of the x-values taken for that
+   * y-value. Initialize with a hard-coded master.
+   * @type {Array}
+   */
+  const taken = [{
+    y: 360,
+    start: branchXCoordinates['master'].start,
+    end: branchXCoordinates['master'].end,
+  }];
+
+  /**
+   * A variable to store the last branch location. Every commit, when being
+   * placed, will be compared to the last commit to see if the branch was
+   * different. If it was different, the new branch will be placed lower.
+   */
+  let lastBranch;
+
+  //get the y-coordinates for each branch
+  Object.keys(allBranches).forEach(branch => {
+    if(!branchXCoordinates[branch] || branch === 'master') return;
+
+    const { start, end } = branchXCoordinates[branch];
+    const yCoordinate = generateY(branch);
+    lastBranch = branch;
+    branchYCoordinates[branch] = yCoordinate;
+    taken.push({ start, end, y: yCoordinate });
+  });
+
+  // if there are 2 branches connected and on the same line, move one
+  let changed = false;
+  do{
+    changed = false;
+    sortedCommits.forEach(commit => {
+      commit.children.forEach(child => {
+        const childObj = commitObj[child];
+        if(childObj && commit.branch !== childObj.branch) {
+          if(branchYCoordinates[commit.branch] === branchYCoordinates[childObj.branch]) {
+            branchYCoordinates[childObj.branch] += yOffset;
+            changed = true;
+          }
+        }
+      });
+    });
+  } while(changed);
+
+  //If there are 2 branches overlapping, move one
+  const branchNames = Object.keys(branchXCoordinates);
+  let altered = false;
+  do{
+    altered = false;
+    branchNames.forEach(thisBranch => {
+      const thisBranchSet = branchXCoordinates[thisBranch];
+      branchNames.forEach(branchToCheck => {
+        //make sure it's not the same branch
+        if(thisBranch !== branchToCheck){
+          //make sure they have the same y-coordinate
+          if(branchYCoordinates[thisBranch] === branchYCoordinates[branchToCheck]){
+            const branchToCheckSet = branchXCoordinates[branchToCheck];
+
+            //Make sure they overlap somewhere along their x-coordinates
+            if(thisBranch !== branchToCheck && checkOverlap(thisBranchSet, branchToCheckSet)) {
+              branchYCoordinates[branchToCheck] += yOffset;
+              altered = true;
+            }
+          }
+        }
+      });
+    });
+  } while(altered);
+
+  //map the branchYCoordinates values over to their commits
+  sortedCommits.forEach(commit => commit.y = branchYCoordinates[commit.branch]);
+}

--- a/src/containers/display_helpers.js
+++ b/src/containers/display_helpers.js
@@ -1,4 +1,12 @@
+import generateCoordinates from './coordinate_generator';
+
 export default {
+  /**
+   * Generate the x and y-coordinates for each commit. Place them as properties
+   * on the commit.
+   */
+  generateCoordinates,
+
   /**
    * Create an HTML anchor tag
    * @param  {String} linkedText - the text you wish to appear
@@ -7,178 +15,6 @@ export default {
    */
   makeAnchor: function (linkedText, site) {
     return `<a href="${site}" target="_blank">${linkedText}</a>`;
-  },
-
-  /**
-   * Generate the x and y-coordinates for each commit. Place them as properties
-   * on the commit.
-   */
-  generateCoordinates: function(sortedCommits, commitObj, allBranches) {
-    /**
-     * Given a range of start and end values, determine if there is any
-     * overlap.
-     * @param  {Object} range1 - the first range, an object with properties
-     *                         start and end
-     * @param  {Object} range2 - the 2nd range, same properties
-     * @return {Boolean} - whether or not they overlap
-     */
-    function checkOverlap(range1, range2) {
-      return (range2.start <= range1.start && range1.start <= range2.end) ||
-        (range2.start <= range1.end && range1.end <= range2.end);
-    }
-
-    /**
-     * Generate an x-value for each commit. Each commit sent in will
-     * have a higher x-value than the one before it. Useful for placing
-     * elements in order. If the next commit will flow off of the screen,
-     * reset the x-value.
-     */
-    function generateX(node) {
-      const nextValue = 40 + numCommits++ * 30;
-      // if(nextValue + 60 > pageWidth) resetXandY();
-      return nextValue;
-    }
-
-    function resetXandY() {
-      numCommits = 1;
-      firstCheckForY += 80;
-    }
-
-    /**
-     * Determine if the y-position we're checking will have overlaps. If so,
-     * put in a different place. Recursively checks the next y-value if the current
-     * one is already taken.
-     * @param  {String} branch - the branch name
-     * @param  {Number} y - the y-value we're checking. Is set automatically,
-     *                    or recursively.
-     * @return {Number} - the y position.
-     */
-    function generateY(branchName, y = firstCheckForY) {
-      //if we're at a new branch we need to jump to another level
-      if(branchName !== lastBranch) {
-        lastBranch = branchName;
-        return generateY(branchName, y + yOffset);
-      }
-
-      let overlap = false;
-
-      const { start: thisBranchStartPoint, end: thisBranchEndPoint } = branchXCoordinates[branchName];
-
-      taken.forEach(set => {
-        if(set.y === y) {
-          if((set.start <= thisBranchStartPoint && thisBranchStartPoint <= set.end) ||
-            (set.start <= thisBranchEndPoint && thisBranchEndPoint <= set.end)) {
-            overlap = true;
-          }
-        }
-      });
-
-      return overlap ? generateY(branchName, y + yOffset) : y;
-    }
-
-    /**
-     * branchXCoordinates will contain the start and end x-values for
-     * each commit.
-     * @type {Object}
-     */
-    const branchXCoordinates = {};
-
-    /**
-     * branchYCoordinates will the y-coordinate of each branch.
-     * @type {Object}
-     */
-    const branchYCoordinates = { master: 360 };
-    let firstCheckForY = 360;
-    let numCommits = 0;
-    const yOffset = 40;
-
-    //Create the x-value for each commit.
-    sortedCommits.forEach(commit => {
-      commit.x = generateX(commit);
-
-      //if it's the first time we're processing a commit from this branch, create an object
-      if(!branchXCoordinates[commit.branch]) {
-        branchXCoordinates[commit.branch] = { start: commit.x };
-      }
-
-      branchXCoordinates[commit.branch].end = commit.x;
-    });
-
-
-    /**
-     * List the positions that are taken. Properties of each object are
-     * a y-value and the range (start and end) of the x-values taken for that
-     * y-value. Initialize with a hard-coded master.
-     * @type {Array}
-     */
-    const taken = [{
-      y: 360,
-      start: branchXCoordinates['master'].start,
-      end: branchXCoordinates['master'].end,
-    }];
-
-    /**
-     * A variable to store the last branch location. Every commit, when being
-     * placed, will be compared to the last commit to see if the branch was
-     * different. If it was different, the new branch will be placed lower.
-     */
-    let lastBranch;
-
-    //get the y-coordinates for each branch
-    Object.keys(allBranches).forEach(branch => {
-      if(!branchXCoordinates[branch] || branch === 'master') return;
-
-      const { start, end } = branchXCoordinates[branch];
-      const yCoordinate = generateY(branch);
-      lastBranch = branch;
-      branchYCoordinates[branch] = yCoordinate;
-      taken.push({ start, end, y: yCoordinate });
-    });
-
-    // if there are 2 branches connected and on the same line, move one
-    let changed = false;
-    do{
-      changed = false;
-      sortedCommits.forEach(commit => {
-        commit.children.forEach(child => {
-          const childObj = commitObj[child];
-          if(childObj && commit.branch !== childObj.branch) {
-            if(branchYCoordinates[commit.branch] === branchYCoordinates[childObj.branch]) {
-              branchYCoordinates[childObj.branch] += yOffset;
-              changed = true;
-            }
-          }
-        });
-      });
-    } while(changed);
-
-    //If there are 2 branches overlapping, move one
-    const branchNames = Object.keys(branchXCoordinates);
-    let altered = false;
-    do{
-      altered = false;
-      branchNames.forEach(thisBranch => {
-        const thisBranchSet = branchXCoordinates[thisBranch];
-        branchNames.forEach(branchToCheck => {
-          //make sure it's not the same branch
-          if(thisBranch !== branchToCheck){
-            //make sure they have the same y-coordinate
-            if(branchYCoordinates[thisBranch] === branchYCoordinates[branchToCheck]){
-              const branchToCheckSet = branchXCoordinates[branchToCheck];
-
-              //Make sure they overlap somewhere along their x-coordinates
-              if(thisBranch !== branchToCheck && checkOverlap(thisBranchSet, branchToCheckSet)) {
-                branchYCoordinates[branchToCheck] += yOffset;
-                altered = true;
-              }
-            }
-          }
-        });
-      });
-    } while(altered);
-
-    //map the branchYCoordinates values over to their commits
-    sortedCommits.forEach(commit => commit.y = branchYCoordinates[commit.branch]);
   },
 
   //https://bl.ocks.org/mbostock/6123708

--- a/src/containers/display_helpers.js
+++ b/src/containers/display_helpers.js
@@ -1,10 +1,12 @@
+/**
+ * display_helpers.js
+ *
+ * Contains helper function used in repo_display.js
+ */
+
 import generateCoordinates from './coordinate_generator';
 
 export default {
-  /**
-   * Generate the x and y-coordinates for each commit. Place them as properties
-   * on the commit.
-   */
   generateCoordinates,
 
   /**
@@ -18,7 +20,7 @@ export default {
   },
 
   //https://bl.ocks.org/mbostock/6123708
-  zoomed: function() {
+  zoomed: function(svg) {
     const { translate, scale } = d3.event;
     svg.selectAll('g')
       .attr("transform", "translate(" + translate + ")scale(" + scale + ")");
@@ -52,7 +54,8 @@ export default {
     }
   },
 
-  //Create an object with some statistics for the commits passed in
+  //Create an object with some statistics for the 
+  //commits and branches passed in
   analyzeRepo: function(commits, branchLookup) {
     function countCommitsPerAuthor(author) {
       return commits.reduce((authorCount, commit) => {
@@ -90,6 +93,10 @@ export default {
   //////////////////////////////////////////////////////////////////
   // NOT DRY. COPIED FROM ORIGINAL LINE RENDERING IN repo_display //
   //////////////////////////////////////////////////////////////////
+  /**
+   * Flip the x and y-values of each node to make the graph vertical.
+   * Delete all lines, then re-render lines.
+   */
   flipXY: function() {
     d3.selectAll('circle')
       .each(function(node) {
@@ -131,8 +138,9 @@ export default {
     });
   },
 
-  //Confusing indentation due to the string literal:
+  //Confusing indentation due to the string interpolation:
   //-----------------------------------------------------------------------------
+  //Show the tooltip with proper commit content.
   showToolTip: function(commit) {
     const { branch, sha, html_url: url, author: { login: authorName } } = commit;
     const repoName = url.match(/\/\/[\w\.]*\/[\w\.]*\/(\w*)\//);

--- a/src/containers/repo_display.js
+++ b/src/containers/repo_display.js
@@ -1,5 +1,7 @@
 /* eslint-disable */
 /**
+ * repo_display.js
+ * 
  * This is the container that displays the repo itself. It needs access to the
  * redux state to receive the commit data returned from the api call. Does not
  * need to dispatch to the redux state.
@@ -68,7 +70,7 @@ class RepoDisplay extends Component {
     //https://bl.ocks.org/mbostock/6123708
     const zoom = d3.behavior.zoom()
       .scaleExtent([0.1, 10])
-      .on("zoom", zoomed);
+      .on("zoom", () => zoomed(svg));
 
     let svg = d3.select('#container').append('svg')
       .attr('width', pageWidth)

--- a/src/containers/repo_display.js
+++ b/src/containers/repo_display.js
@@ -17,6 +17,7 @@ import d3 from '../reducers/gitD3/d3.js';
 import tooltip from '../reducers/gitD3/d3tip.js';
 import _  from 'lodash';
 import $ from 'jquery';
+import helpers from './display_helpers';
 
 d3.tip = tooltip;
 
@@ -35,342 +36,28 @@ class RepoDisplay extends Component {
       this.props.currentRepo.JSONCommits,
       this.props.currentRepo.JSONBranches
     );
-    const { JSONCommits, SHALookup, branchLookup,
-      JSONBranches, originalBranches } = githubTranslator;
 
-    /**
-     * Create an HTML anchor tag
-     * @param  {String} linkedText - the text you wish to appear
-     * @param  {String} site - the site to link to
-     * @return {String} - the anchor HTML element
-     */
-    function makeAnchor(linkedText, site) {
-      return `<a href="${site}" target="_blank">${linkedText}</a>`;
-    }
+    const {
+      SHALookup,
+      branchLookup,
+      JSONBranches,
+      originalBranches,
+      JSONCommits: d3commits
+    } = githubTranslator;
 
-    /**
-     * Generate the x and y-coordinates for each commit. Place them as properties
-     * on the commit.
-     */
-    function generateCoordinates() {
-      /**
-       * Given a range of start and end values, determine if there is any
-       * overlap.
-       * @param  {Object} range1 - the first range, an object with properties
-       *                         start and end
-       * @param  {Object} range2 - the 2nd range, same properties
-       * @return {Boolean} - whether or not they overlap
-       */
-      function checkOverlap(range1, range2) {
-        return (range2.start <= range1.start && range1.start <= range2.end) ||
-          (range2.start <= range1.end && range1.end <= range2.end);
-      }
+    //import helper functions
+    const {
+      makeAnchor,
+      generateCoordinates,
+      zoomed,
+      addColors,
+      analyzeRepo,
+      flipXY,
+      showToolTip,
+    } = helpers;
 
-      /**
-       * Generate an x-value for each commit. Each commit sent in will
-       * have a higher x-value than the one before it. Useful for placing
-       * elements in order. If the next commit will flow off of the screen,
-       * reset the x-value.
-       */
-      function generateX(node) {
-        const nextValue = 40 + numCommits++ * 30;
-        // if(nextValue + 60 > pageWidth) resetXandY();
-        return nextValue;
-      }
-
-      function resetXandY() {
-        numCommits = 1;
-        firstCheckForY += 80;
-      }
-
-      /**
-       * Determine if the y-position we're checking will have overlaps. If so,
-       * put in a different place. Recursively checks the next y-value if the current
-       * one is already taken.
-       * @param  {String} branch - the branch name
-       * @param  {Number} y - the y-value we're checking. Is set automatically,
-       *                    or recursively.
-       * @return {Number} - the y position.
-       */
-      function generateY(branch, y = firstCheckForY) {
-        //if we're at a new branch we need to jump to another level
-        if(branch !== lastBranch) {
-          lastBranch = branch;
-          return generateY(branch, y + yOffset);
-        }
-
-        let overlap = false;
-
-        const { start: thisBranchStartPoint, end: thisBranchEndPoint } = branchXCoordinates[branch];
-
-        taken.forEach(set => {
-          if(set.y === y) {
-            if((set.start <= thisBranchStartPoint && thisBranchStartPoint <= set.end) ||
-              (set.start <= thisBranchEndPoint && thisBranchEndPoint <= set.end)) {
-              overlap = true;
-            }
-          }
-        });
-
-        return overlap ? generateY(branch, y + yOffset) : y;
-      }
-
-      /**
-       * branchXCoordinates will contain the start and end x-values for
-       * each commit.
-       * @type {Object}
-       */
-      const branchXCoordinates = {};
-
-      /**
-       * branchYCoordinates will the y-coordinate of each branch.
-       * @type {Object}
-       */
-      const branchYCoordinates = { master: 360 };
-      let firstCheckForY = 360;
-      let numCommits = 0;
-      const yOffset = 40;
-
-      //Create the x-value for each commit.
-      JSONCommits.forEach(commit => {
-        commit.x = generateX(commit);
-
-        //if it's the first time we're processing a commit from this branch, create an object
-        if(!branchXCoordinates[commit.branch]) {
-          branchXCoordinates[commit.branch] = { start: commit.x };
-        }
-
-        branchXCoordinates[commit.branch].end = commit.x;
-      });
-
-
-      /**
-       * List the positions that are taken. Properties of each object are
-       * a y-value and the range (start and end) of the x-values taken for that
-       * y-value. Initialize with a hard-coded master.
-       * @type {Array}
-       */
-      const taken = [{
-        y: 360,
-        start: branchXCoordinates['master'].start,
-        end: branchXCoordinates['master'].end,
-      }];
-
-      /**
-       * A variable to store the last branch location. Every commit, when being
-       * placed, will be compared to the last commit to see if the branch was
-       * different. If it was different, the new branch will be placed lower.
-       */
-      let lastBranch;
-
-      //get the y-coordinates for each branch
-      Object.keys(branchLookup).forEach(branch => {
-        if(!branchXCoordinates[branch] || branch === 'master') return;
-
-        const { start, end } = branchXCoordinates[branch];
-        const yCoordinate = generateY(branch);
-        lastBranch = branch;
-        branchYCoordinates[branch] = yCoordinate;
-        taken.push({ start, end, y: yCoordinate });
-      });
-
-      // if there are 2 branches connected and on the same line, move one
-      let changed = false;
-      do{
-        changed = false;
-        d3commits.forEach(commit => {
-          commit.children.forEach(child => {
-            const childObj = SHALookup[child];
-            if(childObj && commit.branch !== childObj.branch) {
-              if(branchYCoordinates[commit.branch] === branchYCoordinates[childObj.branch]) {
-                branchYCoordinates[childObj.branch] += yOffset;
-                changed = true;
-              }
-            }
-          });
-        });
-      } while(changed);
-
-      //If there are 2 branches overlapping, move one
-      const allBranches = Object.keys(branchXCoordinates);
-      let altered = false;
-      do{
-        altered = false;
-        allBranches.forEach(thisBranch => {
-          const thisBranchSet = branchXCoordinates[thisBranch];
-          allBranches.forEach(branchToCheck => {
-            //make sure it's not the same branch
-            if(thisBranch !== branchToCheck){
-              //make sure they have the same y-coordinate
-              if(branchYCoordinates[thisBranch] === branchYCoordinates[branchToCheck]){
-                const branchToCheckSet = branchXCoordinates[branchToCheck];
-
-                //Make sure they overlap somewhere along their x-coordinates
-                if(thisBranch !== branchToCheck && checkOverlap(thisBranchSet, branchToCheckSet)) {
-                  branchYCoordinates[branchToCheck] += yOffset;
-                  altered = true;
-                }
-              }
-            }
-          });
-        });
-      } while(altered);
-
-
-      //map the branchYCoordinates values over to their commits
-      d3commits.forEach(commit => commit.y = branchYCoordinates[commit.branch]);
-    }
-
-    //https://bl.ocks.org/mbostock/6123708
-    function zoomed() {
-      const { translate, scale } = d3.event;
-      svg.selectAll('g')
-        .attr("transform", "translate(" + translate + ")scale(" + scale + ")");
-      svg.selectAll('line')
-        .attr("transform", "translate(" + translate + ")scale(" + d3.event.scale + ")");
-
-      //To make the tip essentially disappear from the page we remove its HTML.
-      //It is still present on the page, but now consists of a tiny invisible square.
-      d3.selectAll('.d3-tip')
-        .style('opacity', 0)
-        .html('');
-    }
-
-    //add x and y values to each commit
-    function addCoordinates(nodes) {
-      nodes.forEach(node => {
-        node.x = generateX(node);
-        node.y = generateY(node);
-      });
-    }
-
-    //give each branch a different color property
-    function addColors(branches) {
-      const colors = [
-        '#FA8072',  //salmon
-        "#7D3C98",  //purple
-        "#2471A3",  //blue
-        "#F1C40F",  //yellow
-        '#E67E22',  //orange
-        "#A93226",  //red
-        "#17A589",  //aqua
-        '#839192',  //grey
-        '#000000',  //black
-      ];
-
-      let i = 0;
-      for(let branch in branchLookup) {
-        branchLookup[branch].color = colors[i++ % colors.length];
-      }
-    }
-
-    //Create an object with some statistics for the commits passed in
-    function analyzeRepo(commits) {
-      function countCommitsPerAuthor(author) {
-        return commits.reduce((authorCount, commit) => {
-          if(commit.author.login === author) authorCount++;
-          return authorCount;
-        }, 0);
-      }
-
-      function countCommitsPerBranch(branch) {
-        return commits.reduce((branchCount, commit) => {
-          if(commit.branch === branch) branchCount++;
-          return branchCount;
-        }, 0);
-      }
-
-      const stats = {
-        branches: {},
-        contributors: {},
-      };
-
-      const { branches, contributors } = stats;
-
-      for(let branch in branchLookup) {
-        branches[branch] = branches[branch] || countCommitsPerBranch(branch);
-      }
-
-      commits.forEach((commit) => {
-        const author = commit.author.login;
-        contributors[author] = contributors[author] || countCommitsPerAuthor(author);
-      });
-
-      return stats;
-    }
-
-    ////////////////////////////////////////////////////////
-    //NOT DRY. COPIED FROM ORIGINAL LINE RENDERING BELOW. //
-    ////////////////////////////////////////////////////////
-    function flipXY() {
-      d3.selectAll('circle')
-        .each(function(node) {
-          const x = node.y;
-          const y = node.x;
-          d3.select(this)
-            .attr('cx', x)
-            .attr('cy', y);
-        });
-
-      d3.selectAll('.line')
-        .remove();
-
-      d3commits.forEach(commit => {
-        commit.children.forEach(child => {
-          let childObj = githubTranslator.getCommit(child);
-
-          //this is where the magic happens. Just flip x and y.
-          const curveData = [ { x:commit.y, y:commit.x },{x:childObj.y,  y:childObj.x }];
-          const edge = d3.select("svg").append('g');
-          const diagonal = d3.svg.diagonal()
-            .source(function(d) {return {"x":d[0].y, "y":d[0].x}; })            
-            .target(function(d) {return {"x":d[1].y, "y":d[1].x}; })
-            .projection(function(d) { return [d.y, d.x]; });
-             
-          d3.select("g")
-              .datum(curveData)
-            .append("path")
-              .attr("class", "line")
-              .attr("d", diagonal)
-              .attr("stroke-width", 1)
-            .attr('stroke', branchLookup[commit.branch].color)
-            .attr('fill', 'none');
-        });
-      });
-    }
-
-    function startLoadAnimation() {
-      console.log('loading...')
-      d3.selectAll('circle')
-        .each(function(node) {
-          d3.select(this)
-            .transition()
-            .duration(5000)
-            .attr('cy', pageHeight * 2);
-        });
-    }
-
-    function showToolTip(commit) {
-      const { branch, sha, html_url: url, author: { login: authorName } } = commit;
-      const repoName = url.match(/\/\/[\w\.]*\/[\w\.]*\/(\w*)\//);
-
-      //the ternary operator below: if the branch name is not fake (e.g. master, dev, etc.)
-      //then make it a hyperlink; otherwise, don't display branch name
-      const branchLink = `https://github.com/${authorName}/${repoName[1]}/commits/${branch}`;
-
-      const tooltipContent =
-`${originalBranches.includes(branch) ? 'Branch: ' + makeAnchor(branch, branchLink) + '\n' : '' }SHA:     ${makeAnchor(sha.slice(0, 9) + '...', url)}
-Author:  ${authorName}
-
-Message: ${commit.commit.message}`;
-
-      infoTip.html(`<pre>${tooltipContent}</pre>`);
-      infoTip.show();
-    }
-
-    const d3commits = JSONCommits;
-    addColors(d3commits);
-    generateCoordinates();
+    addColors(branchLookup);
+    generateCoordinates(d3commits, SHALookup, branchLookup);
 
     //http://bl.ocks.org/Caged/6476579
     const infoTip = d3.tip()


### PR DESCRIPTION
- Move repo_display functions to new file, display_helpers.js
- Move generateCoordinates to a new file, coordinate_generator.js
- Major refactor of generateCoordinates function
- Also comment everything in repo_display, display_helpers, and coordinate_generator
